### PR TITLE
Fixed variable name in findScreen

### DIFF
--- a/background.js
+++ b/background.js
@@ -53,7 +53,7 @@ function findScreen(window, screens) {
       return screen;
     }
   }
-  return screen[0];
+  return screens[0];
 }
 
 function updateZoomLevelsForWindow(window, screens) {


### PR DESCRIPTION
Error in var name was causing error when focus changed in maximized window.